### PR TITLE
Revisit delayed slot type checks

### DIFF
--- a/cl-avro.asd
+++ b/cl-avro.asd
@@ -45,6 +45,8 @@
                   :depends-on ("primitive" "ascii")
                   :components ((:file "common")
                                (:file "base")
+                               (:file "late-type-check"
+                                :depends-on ("common" "base"))
                                (:module "named"
                                 :depends-on ("common" "base")
                                 :serial t

--- a/src/schema/complex/late-type-check.lisp
+++ b/src/schema/complex/late-type-check.lisp
@@ -1,0 +1,146 @@
+;;; Copyright 2021 Google LLC
+;;;
+;;; This file is part of cl-avro.
+;;;
+;;; cl-avro is free software: you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation, either version 3 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; cl-avro is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with cl-avro.  If not, see <http://www.gnu.org/licenses/>.
+
+(in-package #:cl-user)
+(defpackage #:cl-avro.schema.complex.late-type-check
+  (:use #:cl)
+  (:import-from #:cl-avro.schema.complex.common
+                #:define-initializers)
+  (:import-from #:cl-avro.schema.complex.base
+                #:ensure-superclass)
+  (:export #:late-class
+           #:parse-slot-value))
+(in-package #:cl-avro.schema.complex.late-type-check)
+
+;;; late-slot
+
+(defclass late-slot (closer-mop:standard-direct-slot-definition)
+  ((late-type
+    :type (or symbol cons)
+    :reader late-type)))
+
+(defmethod initialize-instance :around
+    ((instance late-slot)
+     &rest initargs
+     &key
+       (late-type (error "Must supply LATE-TYPE"))
+       (early-type `(or symbol ,late-type)))
+  (setf (getf initargs :type) early-type)
+  (remf initargs :early-type)
+  (remf initargs :late-type)
+  (let ((instance (apply #'call-next-method instance initargs)))
+    (setf (slot-value instance 'late-type) late-type)))
+
+;;; finalizing-reader
+
+(defclass finalizing-reader (closer-mop:standard-reader-method)
+  ())
+
+(defmethod initialize-instance :around
+    ((instance finalizing-reader) &rest initargs &key slot-definition)
+  (let* ((gf
+           (symbol-function
+            (first (closer-mop:slot-definition-readers slot-definition))))
+         (lambda
+             `(lambda (class)
+                (unless (closer-mop:class-finalized-p class)
+                  (closer-mop:finalize-inheritance class))))
+         (method-lambda
+           (closer-mop:make-method-lambda
+            gf (closer-mop:class-prototype (class-of instance)) lambda nil))
+         (documentation
+           "Finalizes class before reader method executes.")
+         (primary-method
+           (call-next-method))
+         (before-method
+           (let ((instance (allocate-instance (class-of instance))))
+             (setf (getf initargs :qualifiers) '(:before)
+                   (getf initargs :documentation) documentation
+                   (getf initargs :function) (compile nil method-lambda))
+             (apply #'call-next-method instance initargs))))
+    (add-method gf before-method)
+    primary-method))
+
+;;; late-class
+
+(defclass late-class (standard-class)
+  ())
+
+(defmethod closer-mop:validate-superclass
+    ((class late-class) (superclass standard-class))
+  t)
+
+(defmethod closer-mop:direct-slot-definition-class
+    ((class late-class) &rest initargs)
+  (if (or (member :early-type initargs)
+          (member :late-type initargs))
+      (find-class 'late-slot)
+      (call-next-method)))
+
+(defmethod closer-mop:reader-method-class
+    ((class late-class) slot &rest initargs)
+  (declare (ignore class slot initargs))
+  (find-class 'finalizing-reader))
+
+(define-initializers late-class :around
+    (&rest initargs)
+  (ensure-superclass late-object)
+  (apply #'call-next-method instance initargs))
+
+;;; late-object
+
+(defclass late-object ()
+  ())
+
+(defmethod closer-mop:finalize-inheritance :before
+    ((instance late-object))
+  ;; complex-schema would have already checked the slots against
+  ;; regular/early type so we just need to perform the late-binding
+  ;; checks
+  (flet ((not-late-slot-p (slot)
+           (not (typep slot 'late-slot)))
+         (process-slot (slot)
+           (process-slot instance slot)))
+    (let ((slots (remove-if
+                  #'not-late-slot-p
+                  (closer-mop:class-direct-slots
+                   (class-of instance)))))
+      (map nil #'process-slot slots))))
+
+(declaim
+ (ftype (function (late-object late-slot) (values &optional)) process-slot))
+(defun process-slot (class slot)
+  (let* ((name (closer-mop:slot-definition-name slot))
+         (type (late-type slot))
+         (value (parse-slot-value
+                 class
+                 name
+                 type
+                 (when (slot-boundp class name)
+                   (slot-value class name)))))
+    (unless (typep value type)
+      (error "Slot ~S expects type ~S: ~S" name type value))
+    (setf (slot-value class name) value))
+  (values))
+
+(defgeneric parse-slot-value (class name type value)
+  (:method (class (name symbol) type value)
+    (declare (ignore class name))
+    (if (and (symbolp value)
+             (not (typep value type)))
+        (find-class value)
+        value)))

--- a/src/schema/complex/map.lisp
+++ b/src/schema/complex/map.lisp
@@ -34,6 +34,8 @@
                 #:hashmap
                 #:hashref
                 #:hashrem)
+  (:import-from #:cl-avro.schema.complex.late-type-check
+                #:late-class)
   (:export #:map
            #:map-object
            #:values
@@ -51,9 +53,13 @@
 
 (defclass map (complex-schema)
   ((values
+    :initarg :values
     :reader values
-    :type schema
+    :late-type schema
     :documentation "Map schema value type."))
+  (:metaclass late-class)
+  (:default-initargs
+   :values (error "Must supply VALUES"))
   (:documentation
    "Base class for avro map schemas."))
 
@@ -65,20 +71,6 @@
     (&rest initargs)
   (ensure-superclass map-object)
   (apply #'call-next-method instance initargs))
-
-(declaim (ftype (function (t) (cl:values schema &optional)) parse-values))
-(defun parse-values (values)
-  (let ((values
-          (if (and (symbolp values)
-                   (not (typep values 'schema)))
-              (find-class values)
-              values)))
-    (check-type values schema)
-    values))
-
-(define-initializers map :after
-    (&key (values (error "Must supply VALUES")))
-  (setf (slot-value instance 'values) (parse-values values)))
 
 ;;; object
 

--- a/src/schema/complex/package.lisp
+++ b/src/schema/complex/package.lisp
@@ -28,12 +28,17 @@
         #:cl-avro.schema.complex.record)
   (:import-from #:cl-avro.schema.complex.common
                 #:define-initializers)
+  (:import-from #:cl-avro.schema.complex.late-type-check
+                #:late-class
+                #:parse-slot-value)
   (:export #:schema
            #:object
            #:which-one
            #:default
            #:raw-buffer
            #:define-initializers
+           #:late-class
+           #:parse-slot-value
 
            #:complex-schema
            #:complex-object

--- a/src/schema/io/read.lisp
+++ b/src/schema/io/read.lisp
@@ -26,6 +26,7 @@
   (:import-from #:cl-avro.schema.primitive
                 #:+primitive->name+)
   (:import-from #:cl-avro.schema.complex
+                #:late-class
                 #:schema
                 #:named-schema
                 #:fullname
@@ -65,7 +66,10 @@
         (*error-on-duplicate-name-p* t))
     (declare (special *fullname->schema* *enclosing-namespace*
                       *error-on-duplicate-name-p*))
-    (parse-schema (st-json:read-json json))))
+    (let ((schema (parse-schema (st-json:read-json json))))
+      (when (typep (class-of schema) 'late-class)
+        (closer-mop:finalize-inheritance schema))
+      schema)))
 
 (declaim
  (ftype (function ((or list simple-string st-json:jso))

--- a/src/schema/io/write/write.lisp
+++ b/src/schema/io/write/write.lisp
@@ -37,6 +37,7 @@
 
                 #:duration)
   (:import-from #:cl-avro.schema.complex
+                #:late-class
                 #:schema
                 #:named-schema
                 #:name
@@ -76,6 +77,8 @@
   "Write json representation of avro SCHEMA into STREAM.
 
 If CANONICAL-FORM is true, then the Canonical Form is written."
+  (when (typep (class-of schema) 'late-class)
+    (closer-mop:finalize-inheritance schema))
   (let* ((*seen* (make-hash-table :test #'eq))
          (schema (if canonical-form
                      (canonicalize schema)

--- a/src/schema/logical/base.lisp
+++ b/src/schema/logical/base.lisp
@@ -25,14 +25,11 @@
            #:underlying))
 (in-package #:cl-avro.schema.logical.base)
 
-(defclass effective-slot (closer-mop:standard-effective-slot-definition)
-  ((type
-    :type schema)))
-
 (defclass logical-schema (complex-schema)
   ((underlying
     :initarg :underlying
     :type (or schema symbol)
+    :reader underlying
     :documentation "Underlying schema for logical schema."))
   (:default-initargs
    :underlying (error "Must supply UNDERLYING"))
@@ -42,41 +39,3 @@
 (defmethod closer-mop:validate-superclass
     ((class logical-schema) (superclass complex-schema))
   t)
-
-;; this never gets called because the logcial schemas are all
-;; instances of standard class...I'll need a custom metaclass for them
-(defmethod closer-mop:compute-effective-slot-definition
-    ((class logical-schema) (name (eql 'underlying)) slots)
-  (let ((effective-slot (call-next-method)))
-    (with-accessors
-          ((name closer-mop:slot-definition-name)
-           (initform closer-mop:slot-definition-initform)
-           (initfunction closer-mop:slot-definition-initfunction)
-           (type closer-mop:slot-definition-type)
-           (allocation closer-mop:slot-definition-allocation)
-           (initargs closer-mop:slot-definition-initargs)
-           (readers closer-mop:slot-definition-readers)
-           (writers closer-mop:slot-definition-writers))
-        effective-slot
-      (let* ((documentation (documentation effective-slot t))
-             (initargs (list :name name :allocation allocation :initargs initargs
-                             :readers readers :writers writers
-                             :documentation documentation :type type)))
-        (when initfunction
-          (setf initargs (list* :initform initform :initfunction initfunction
-                                initargs)))
-        (apply #'make-instance 'effective-slot initargs)))))
-
-(defmethod closer-mop:finalize-inheritance :after
-    ((instance logical-schema))
-  (with-slots (underlying) instance
-    (when (and (symbolp underlying)
-               (not (typep underlying 'schema)))
-      (setf underlying (find-class underlying)))
-    (check-type underlying schema)))
-
-(defgeneric underlying (logical-schema)
-  (:method ((instance logical-schema))
-    (unless (closer-mop:class-finalized-p instance)
-      (closer-mop:finalize-inheritance instance))
-    (slot-value instance 'underlying)))

--- a/test/complex/array.lisp
+++ b/test/complex/array.lisp
@@ -158,3 +158,22 @@
     (let ((deserialized (avro:deserialize array-schema serialized)))
       (is (eq array-schema (class-of deserialized)))
       (is (equal expected (map 'list #'avro:which-one deserialized))))))
+
+(test late-type-check
+  (setf (find-class 'late_array) nil
+        (find-class 'late_enum) nil)
+
+  (defclass late_array ()
+    ()
+    (:metaclass avro:array)
+    (:items late_enum))
+
+  (signals error
+    (avro:items (find-class 'late_array)))
+
+  (defclass late_enum ()
+    ()
+    (:metaclass avro:enum)
+    (:symbols "FOO" "BAR"))
+
+  (is (eq (find-class 'late_enum) (avro:items (find-class 'late_array)))))

--- a/test/complex/map.lisp
+++ b/test/complex/map.lisp
@@ -154,3 +154,22 @@
       (let ((deserialized (avro:deserialize map-schema serialized)))
         (is (eq map-schema (class-of deserialized)))
         (is (equal expected (sorted-alist deserialized)))))))
+
+(test late-type-check
+  (setf (find-class 'late_map) nil
+        (find-class 'late_enum) nil)
+
+  (defclass late_map ()
+    ()
+    (:metaclass avro:map)
+    (:values late_enum))
+
+  (signals error
+    (avro:values (find-class 'late_map)))
+
+  (defclass late_enum ()
+    ()
+    (:metaclass avro:enum)
+    (:symbols "FOO" "BAR"))
+
+  (is (eq (find-class 'late_enum) (avro:values (find-class 'late_map)))))

--- a/test/complex/union.lisp
+++ b/test/complex/union.lisp
@@ -94,3 +94,78 @@
     (is (null (avro:object (make-instance schema :object nil))))
     (signals error
       (make-instance schema :object 3))))
+
+(test late-type-check
+  (setf (find-class 'late_union) nil
+        (find-class 'late_fixed) nil)
+
+  (defclass late_union ()
+    ()
+    (:metaclass avro:union)
+    (:schemas avro:string late_fixed))
+
+  (signals error
+    (avro:schemas (find-class 'late_union)))
+
+  (defclass late_fixed ()
+    ()
+    (:metaclass avro:fixed)
+    (:size 12))
+
+  (is (eq (find-class 'late_fixed)
+          (elt (avro:schemas (find-class 'late_union)) 1))))
+
+(test no-schemas
+  (signals error
+    (make-instance
+     'avro:union
+     :schemas #())))
+
+(test non-schema
+  (setf (find-class 'some_union) nil
+        (find-class 'some_class) nil)
+
+  (defclass some_class ()
+    ())
+
+  (defclass some_union ()
+    ()
+    (:metaclass avro:union)
+    (:schemas avro:string some_class))
+
+  (signals error
+    (avro:schemas (find-class 'some_union))))
+
+(test duplicate-primitive
+  (let ((schema (make-instance
+                 'avro:union
+                 :schemas '(avro:string avro:null avro:string))))
+    (signals error
+      (avro:schemas schema))))
+
+(test duplicate-array
+  (let* ((array<int> (make-instance 'avro:array :items 'avro:int))
+         (array<string> (make-instance 'avro:array :items 'avro:string))
+         (schema (make-instance
+                  'avro:union
+                  :schemas (list 'avro:null array<int> array<string>))))
+    (signals error
+      (avro:schemas schema))))
+
+(test duplicate-named
+  (let* ((fixed (make-instance 'avro:fixed :name "foo" :size 12))
+         (enum (make-instance 'avro:enum :name "foo" :symbols '("FOO" "BAR")))
+         (schema (make-instance
+                  'avro:union
+                  :schemas (list 'avro:null fixed enum))))
+    (signals error
+      (avro:schemas schema))))
+
+(test different-name-same-type
+  (let* ((fixed-1 (make-instance 'avro:fixed :name "foo" :size 12))
+         (fixed-2 (make-instance 'avro:fixed :name "bar" :size 12))
+         (schema (make-instance
+                  'avro:union
+                  :schemas (list 'avro:null fixed-1 fixed-2))))
+    (is (equalp (vector 'avro:null fixed-1 fixed-2)
+                (avro:schemas schema)))))

--- a/test/logical/duration.lisp
+++ b/test/logical/duration.lisp
@@ -99,3 +99,32 @@
       (let ((deserialized (avro:deserialize schema serialized)))
         (is (eq schema (class-of deserialized)))
         (check deserialized)))))
+
+(test late-type-check
+  (setf (find-class 'late_duration) nil
+        (find-class 'late_fixed) nil)
+
+  (defclass late_duration ()
+    ()
+    (:metaclass avro:duration)
+    (:underlying late_fixed))
+
+  (signals error
+    (avro:underlying (find-class 'late_duration)))
+
+  (defclass late_fixed ()
+    ()
+    (:metaclass avro:fixed)
+    (:size 12))
+
+  (is (eq (find-class 'late_fixed) (avro:underlying (find-class 'late_duration)))))
+
+(test bad-fixed-size
+  (let ((schema (make-instance
+                 'avro:duration
+                 :underlying (make-instance
+                              'avro:fixed
+                              :name "foo"
+                              :size 13))))
+    (signals error
+      (avro:underlying schema))))


### PR DESCRIPTION
This resolves the shortcomings from 72eef57:
* delayed slots are type-checked
* forward-referenced schemas are supported