### PR TITLE
Get rid of extra type slot in field

### DIFF
--- a/src/schema/complex/record/effective-field.lisp
+++ b/src/schema/complex/record/effective-field.lisp
@@ -41,9 +41,7 @@
 
 (defclass effective-field (field:field
                            closer-mop:standard-effective-slot-definition)
-  ((field:type
-    :type schema)
-   (field:default
+  ((field:default
     :type object)))
 
 (declaim (ftype (function (t schema) (values t &optional)) %parse-default))
@@ -89,9 +87,7 @@
 
 (defmethod initialize-instance :after
     ((instance effective-field) &key)
-  (with-accessors
-        ((type closer-mop:slot-definition-type))
-      instance
+  (let ((type (field:type instance)))
     (check-type type schema)))
 
 (declaim

--- a/src/schema/complex/record/field.lisp
+++ b/src/schema/complex/record/field.lisp
@@ -66,12 +66,7 @@
    (default
     :initarg :default
     :type t
-    :documentation "Field default.")
-   (type
-    :initarg :type
-    :reader type
-    :type (or schema symbol)
-    :documentation "Field type."))
+    :documentation "Field default."))
   (:default-initargs
    :name (error "Must supply NAME")
    :type (error "Must supply TYPE"))
@@ -100,6 +95,11 @@
   (let ((name (closer-mop:slot-definition-name instance)))
     (declare (symbol name))
     (values (string name) name)))
+
+(defgeneric type (field)
+  (:method ((instance field))
+    "Field type."
+    (closer-mop:slot-definition-type instance)))
 
 (declaim
  (ftype (function (sequence boolean)
@@ -146,8 +146,10 @@
         ((name closer-mop:slot-definition-name)
          (initfunction closer-mop:slot-definition-initfunction)
          (initform closer-mop:slot-definition-initform)
-         (allocation closer-mop:slot-definition-allocation))
+         (allocation closer-mop:slot-definition-allocation)
+         (type closer-mop:slot-definition-type))
       instance
+    (check-type type (or schema symbol))
     (let ((name (string name)))
       (check-type name name))
     (when initfunction


### PR DESCRIPTION
Slot metaobjects already have a slot to hold type info, though it's
not necessarily called type. SBCL calls it %type, for example.