### PR TITLE
Use scalarize-class instead of ensure-class

### DIFF
--- a/cl-avro.asd
+++ b/cl-avro.asd
@@ -45,22 +45,24 @@
                   :depends-on ("primitive" "ascii")
                   :components ((:file "common")
                                (:file "base")
-                               (:file "late-type-check"
+                               (:file "scalarize"
                                 :depends-on ("common" "base"))
+                               (:file "late-type-check"
+                                :depends-on ("common" "base" "scalarize"))
                                (:module "named"
-                                :depends-on ("common" "base")
+                                :depends-on ("common" "base" "scalarize")
                                 :serial t
                                 :components ((:file "type")
                                              (:file "schema")
                                              (:file "package")))
                                (:file "array"
-                                :depends-on ("base"))
+                                :depends-on ("base" "late-type-check"))
                                (:file "enum"
                                 :depends-on ("common" "base" "named"))
                                (:file "fixed"
                                 :depends-on ("base" "named"))
                                (:file "map"
-                                :depends-on ("base"))
+                                :depends-on ("base" "late-type-check"))
                                (:file "union"
                                 :depends-on ("common" "base" "named"))
                                (:module "record"
@@ -80,6 +82,8 @@
                                              (:file "package")))
                                (:file "package"
                                 :depends-on ("base"
+                                             "scalarize"
+                                             "late-type-check"
                                              "named"
                                              "array"
                                              "enum"

--- a/src/schema/complex/array.lisp
+++ b/src/schema/complex/array.lisp
@@ -30,6 +30,8 @@
                 #:schema)
   (:import-from #:cl-avro.schema.complex.late-type-check
                 #:late-class)
+  (:import-from #:cl-avro.schema.complex.scalarize
+                #:scalarize-value)
   (:export #:array
            #:array-object
            #:raw-buffer
@@ -47,6 +49,7 @@
     :late-type schema
     :documentation "Array schema element type."))
   (:metaclass late-class)
+  (:scalarize :items)
   (:default-initargs
    :items (error "Must supply ITEMS"))
   (:documentation
@@ -65,7 +68,7 @@
 
 (define-initializers array :around
     (&rest initargs &key items)
-  (let ((buffer-slot (make-buffer-slot items)))
+  (let ((buffer-slot (make-buffer-slot (scalarize-value items))))
     (cl:push buffer-slot (getf initargs :direct-slots)))
   (ensure-superclass array-object)
   (apply #'call-next-method instance initargs))

--- a/src/schema/complex/enum.lisp
+++ b/src/schema/complex/enum.lisp
@@ -26,8 +26,7 @@
                 #:define-initializers)
   (:import-from #:cl-avro.schema.complex.base
                 #:complex-schema
-                #:ensure-superclass
-                #:scalarize-initargs)
+                #:ensure-superclass)
   (:import-from #:cl-avro.schema.complex.named
                 #:named-schema
                 #:name
@@ -36,6 +35,9 @@
                 #:aliases)
   (:import-from #:cl-avro.schema.primitive
                 #:int)
+  (:import-from #:cl-avro.schema.complex.scalarize
+                #:scalarize-class
+                #:scalarize-value)
   (:export #:enum
            #:enum-object
            #:symbols
@@ -62,6 +64,8 @@
     :initarg :default
     :type (or null position)
     :documentation "Position of enum default."))
+  (:metaclass scalarize-class)
+  (:scalarize :default)
   (:default-initargs
    :symbols (error "Must supply SYMBOLS")
    :default nil)
@@ -102,7 +106,7 @@
 (define-initializers enum :around
     (&rest initargs &key symbols default)
   (let* ((symbols (parse-symbols symbols))
-         (default (parse-default symbols default)))
+         (default (parse-default symbols (scalarize-value default))))
     (setf (getf initargs :symbols) symbols
           (getf initargs :default) default))
   (ensure-superclass enum-object)
@@ -114,13 +118,6 @@
     (if default
         (values (elt symbols default) default)
         (values nil nil))))
-
-(defmethod scalarize-initargs
-    ((metaclass (eql 'enum)) (initargs list))
-  (let ((symbols (getf initargs :symbols)))
-    (if (remf initargs :symbols)
-        (list* :symbols symbols (scalarize-initargs 'named-schema initargs))
-        (scalarize-initargs 'named-schema initargs))))
 
 ;;; object
 

--- a/src/schema/complex/fixed.lisp
+++ b/src/schema/complex/fixed.lisp
@@ -32,6 +32,9 @@
                 #:namespace
                 #:fullname
                 #:aliases)
+  (:import-from #:cl-avro.schema.complex.scalarize
+                #:scalarize-class
+                #:scalarize-value)
   (:export #:fixed
            #:fixed-object
            #:raw-buffer
@@ -50,6 +53,8 @@
     :reader size
     :type (integer 0)
     :documentation "Fixed schema size."))
+  (:metaclass scalarize-class)
+  (:scalarize :size)
   (:default-initargs
    :size (error "Must supply SIZE"))
   (:documentation
@@ -67,7 +72,7 @@
 
 (define-initializers fixed :around
     (&rest initargs &key size)
-  (let ((buffer-slot (make-buffer-slot size)))
+  (let ((buffer-slot (make-buffer-slot (scalarize-value size))))
     (push buffer-slot (getf initargs :direct-slots)))
   (ensure-superclass fixed-object)
   (apply #'call-next-method instance initargs))

--- a/src/schema/complex/late-type-check.lisp
+++ b/src/schema/complex/late-type-check.lisp
@@ -22,6 +22,8 @@
                 #:define-initializers)
   (:import-from #:cl-avro.schema.complex.base
                 #:ensure-superclass)
+  (:import-from #:cl-avro.schema.complex.scalarize
+                #:scalarize-class)
   (:export #:late-class
            #:parse-slot-value))
 (in-package #:cl-avro.schema.complex.late-type-check)
@@ -77,11 +79,11 @@
 
 ;;; late-class
 
-(defclass late-class (standard-class)
+(defclass late-class (scalarize-class)
   ())
 
 (defmethod closer-mop:validate-superclass
-    ((class late-class) (superclass standard-class))
+    ((class late-class) (superclass scalarize-class))
   t)
 
 (defmethod closer-mop:direct-slot-definition-class

--- a/src/schema/complex/map.lisp
+++ b/src/schema/complex/map.lisp
@@ -58,6 +58,7 @@
     :late-type schema
     :documentation "Map schema value type."))
   (:metaclass late-class)
+  (:scalarize :values)
   (:default-initargs
    :values (error "Must supply VALUES"))
   (:documentation

--- a/src/schema/complex/package.lisp
+++ b/src/schema/complex/package.lisp
@@ -31,12 +31,15 @@
   (:import-from #:cl-avro.schema.complex.late-type-check
                 #:late-class
                 #:parse-slot-value)
+  (:import-from #:cl-avro.schema.complex.scalarize
+                #:scalarize-class)
   (:export #:schema
            #:object
            #:which-one
            #:default
            #:raw-buffer
            #:define-initializers
+           #:scalarize-class
            #:late-class
            #:parse-slot-value
 

--- a/src/schema/complex/record/schema.lisp
+++ b/src/schema/complex/record/schema.lisp
@@ -42,6 +42,8 @@
                 #:parse-notation)
   (:import-from #:cl-avro.schema.complex.common
                 #:define-initializers)
+  (:import-from #:cl-avro.schema.complex.scalarize
+                #:scalarize-class)
   (:shadowing-import-from #:cl-avro.schema.complex.record.field
                           #:type)
   (:export #:record
@@ -59,6 +61,7 @@
     :reader nullable-fields
     :type hash-table
     :documentation "Nullable fields."))
+  (:metaclass scalarize-class)
   (:documentation
    "Base class for avro record schemas."))
 

--- a/src/schema/complex/scalarize.lisp
+++ b/src/schema/complex/scalarize.lisp
@@ -1,0 +1,108 @@
+;;; Copyright 2021 Google LLC
+;;;
+;;; This file is part of cl-avro.
+;;;
+;;; cl-avro is free software: you can redistribute it and/or modify
+;;; it under the terms of the GNU General Public License as published by
+;;; the Free Software Foundation, either version 3 of the License, or
+;;; (at your option) any later version.
+;;;
+;;; cl-avro is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with cl-avro.  If not, see <http://www.gnu.org/licenses/>.
+
+(in-package #:cl-user)
+(defpackage #:cl-avro.schema.complex.scalarize
+  (:use #:cl)
+  (:import-from #:cl-avro.schema.complex.common
+                #:define-initializers)
+  (:import-from #:cl-avro.schema.complex.base
+                #:ensure-superclass)
+  (:export #:scalarize-class
+           #:scalarize-value))
+(in-package #:cl-avro.schema.complex.scalarize)
+
+;;; scalarize-class
+
+(defclass scalarize-class (standard-class)
+  ((scalarize
+    :initarg :scalarize
+    :reader scalarize
+    :type list
+    :documentation "Initargs to scalarize."))
+  (:default-initargs
+   :scalarize nil))
+
+(defmethod closer-mop:validate-superclass
+    ((class scalarize-class) (superclass standard-class))
+  t)
+
+(define-initializers scalarize-class :around
+    (&rest initargs)
+  (ensure-superclass scalarize-object)
+  (apply #'call-next-method instance initargs))
+
+(define-initializers scalarize-class :after
+    (&key)
+  (flet ((assert-keyword (arg)
+           (check-type arg keyword)))
+    (map nil #'assert-keyword (scalarize instance))))
+
+;;; scalarize-object
+
+(defclass scalarize-object ()
+  ())
+
+(declaim (ftype (function (cons) (values t &optional)) scalarize-list))
+(defun scalarize-list (list)
+  (if (= (length list) 1)
+      (first list)
+      list))
+
+(declaim (ftype (function (t) (values t &optional)) scalarize-value))
+(defun scalarize-value (value)
+  (if (consp value)
+      (scalarize-list value)
+      value))
+
+(declaim
+ (ftype (function (scalarize-class) (values list &optional))
+        initargs-to-scalarize))
+(defun initargs-to-scalarize (class)
+  (loop
+    for superclass in (closer-mop:class-direct-superclasses class)
+
+    when (typep superclass 'scalarize-class)
+      append (scalarize superclass) into initargs
+
+    finally
+       (return
+         (delete-duplicates
+          (append (scalarize class) initargs)))))
+
+(define-initializers scalarize-object :around
+    (&rest initargs)
+  (loop
+    with initargs-to-scalarize = (initargs-to-scalarize (class-of instance))
+
+    for remaining = initargs then (cddr remaining)
+    while remaining
+    for arg = (car remaining)
+    for rest = (cdr remaining)
+    for value = (car rest)
+
+    unless rest do
+      (error "Odd number of key-value pairs: ~S" initargs)
+
+    if (member arg initargs-to-scalarize)
+      nconc (list arg (scalarize-value value)) into scalarized-initargs
+    else
+      nconc (list arg value) into scalarized-initargs
+
+    finally
+       (return
+         (apply #'call-next-method instance scalarized-initargs))))

--- a/src/schema/complex/union.lisp
+++ b/src/schema/complex/union.lisp
@@ -24,8 +24,7 @@
                 #:complex-schema
                 #:ensure-superclass
                 #:schema
-                #:object
-                #:scalarize-initargs)
+                #:object)
   (:import-from #:cl-avro.schema.complex.named
                 #:named-schema
                 #:valid-fullname
@@ -210,13 +209,6 @@
     (setf schemas (parse-schemas schemas)
           wrapper-classes (make-wrapper-classes schemas))
     schemas))
-
-(defmethod scalarize-initargs
-    ((metaclass (eql 'union)) (initargs list))
-  (let ((schemas (getf initargs :schemas)))
-    (if (remf initargs :schemas)
-        (list* :schemas schemas (scalarize-initargs 'complex-schema initargs))
-        (scalarize-initargs 'complex-schema initargs))))
 
 ;; object
 

--- a/src/schema/logical/base.lisp
+++ b/src/schema/logical/base.lisp
@@ -20,7 +20,8 @@
   (:use #:cl)
   (:import-from #:cl-avro.schema.complex
                 #:complex-schema
-                #:schema)
+                #:schema
+                #:scalarize-class)
   (:export #:logical-schema
            #:underlying))
 (in-package #:cl-avro.schema.logical.base)
@@ -31,6 +32,8 @@
     :type (or schema symbol)
     :reader underlying
     :documentation "Underlying schema for logical schema."))
+  (:metaclass scalarize-class)
+  (:scalarize :underlying)
   (:default-initargs
    :underlying (error "Must supply UNDERLYING"))
   (:documentation

--- a/src/schema/logical/date.lisp
+++ b/src/schema/logical/date.lisp
@@ -26,6 +26,8 @@
                 #:timezone)
   (:import-from #:cl-avro.schema.primitive
                 #:int)
+  (:import-from #:cl-avro.schema.complex
+                #:scalarize-class)
   (:export #:date-schema
            #:underlying
            #:date-mixin
@@ -63,6 +65,7 @@
 (defclass date-schema (logical-schema)
   ((underlying
     :type (eql int)))
+  (:metaclass scalarize-class)
   (:default-initargs
    :underlying 'int)
   (:documentation

--- a/src/schema/logical/decimal.lisp
+++ b/src/schema/logical/decimal.lisp
@@ -56,6 +56,7 @@
     :type (integer 1)
     :documentation "Decimal precision."))
   (:metaclass late-class)
+  (:scalarize :scale :precision)
   (:default-initargs
    :precision (error "Must supply PRECISION"))
   (:documentation

--- a/src/schema/logical/local-timestamp.lisp
+++ b/src/schema/logical/local-timestamp.lisp
@@ -35,6 +35,8 @@
                 #:minute)
   (:import-from #:cl-avro.schema.logical.timezone
                 #:timezone)
+  (:import-from #:cl-avro.schema.complex
+                #:scalarize-class)
   (:shadowing-import-from #:cl-avro.schema.logical.time
                           #:second)
   (:export #:local-timestamp-millis-schema
@@ -58,6 +60,7 @@
 (defclass local-timestamp-millis-schema (logical-schema)
   ((underlying
     :type (eql long)))
+  (:metaclass scalarize-class)
   (:default-initargs
    :underlying 'long)
   (:documentation
@@ -87,6 +90,7 @@ regardless of what specific timezone is considered local."))
 (defclass local-timestamp-micros-schema (logical-schema)
   ((underlying
     :type (eql long)))
+  (:metaclass scalarize-class)
   (:default-initargs
    :underlying 'long)
   (:documentation

--- a/src/schema/logical/time.lisp
+++ b/src/schema/logical/time.lisp
@@ -28,6 +28,8 @@
   (:import-from #:cl-avro.schema.primitive
                 #:int
                 #:long)
+  (:import-from #:cl-avro.schema.complex
+                #:scalarize-class)
   (:export #:time-millis-schema
            #:time-micros-schema
            #:underlying
@@ -90,6 +92,7 @@
 (defclass time-millis-schema (logical-schema)
   ((underlying
     :type (eql int)))
+  (:metaclass scalarize-class)
   (:default-initargs
    :underlying 'int)
   (:documentation
@@ -122,6 +125,7 @@ to a particular calendar, timezone, or date."))
 (defclass time-micros-schema (logical-schema)
   ((underlying
     :type (eql long)))
+  (:metaclass scalarize-class)
   (:default-initargs
    :underlying 'long)
   (:documentation

--- a/src/schema/logical/timestamp.lisp
+++ b/src/schema/logical/timestamp.lisp
@@ -30,6 +30,8 @@
   (:import-from #:cl-avro.schema.logical.time
                 #:hour
                 #:minute)
+  (:import-from #:cl-avro.schema.complex
+                #:scalarize-class)
   (:shadowing-import-from #:cl-avro.schema.logical.time
                           #:second)
   (:export #:timestamp-millis-schema
@@ -52,6 +54,7 @@
 (defclass timestamp-millis-schema (logical-schema)
   ((underlying
     :type (eql long)))
+  (:metaclass scalarize-class)
   (:default-initargs
    :underlying 'long)
   (:documentation
@@ -149,6 +152,7 @@ timeline, independent of a particular timezone or calendar."))
 (defclass timestamp-micros-schema (logical-schema)
   ((underlying
     :type (eql long)))
+  (:metaclass scalarize-class)
   (:default-initargs
    :underlying 'long)
   (:documentation

--- a/src/schema/logical/uuid.lisp
+++ b/src/schema/logical/uuid.lisp
@@ -23,6 +23,8 @@
                 #:underlying)
   (:import-from #:cl-avro.schema.ascii
                 #:hex-p)
+  (:import-from #:cl-avro.schema.complex
+                #:scalarize-class)
   (:shadowing-import-from #:cl-avro.schema.primitive
                           #:string)
   (:export #:uuid-schema
@@ -52,6 +54,7 @@
 (defclass uuid-schema (logical-schema)
   ((underlying
     :type (eql string)))
+  (:metaclass scalarize-class)
   (:default-initargs
    :underlying 'string)
   (:documentation


### PR DESCRIPTION
The ensure-class-using-class approach was brittle: since it didn't
specialize any of the args, it could be inadvertently overridden by
library users.

This approach is also opt-in instead of opt-out, like it was
previously.