### PR TITLE
Flatten logical schemas

### DIFF
--- a/src/logical/decimal.lisp
+++ b/src/logical/decimal.lisp
@@ -372,9 +372,14 @@
                     "logicalType" "decimal"))
               fullname->schema
               enclosing-namespace)
-      (let ((underlying (internal:read-jso (st-json:getjso "type" jso)
-                                           fullname->schema
-                                           enclosing-namespace)))
+      (let ((underlying
+              (internal:read-jso
+               (prog1 jso
+                 (setf (st-json::jso-alist jso)
+                       (delete "logicalType" (st-json::jso-alist jso)
+                               :key #'car :test #'string=)))
+               fullname->schema
+               enclosing-namespace)))
         (handler-case
             (internal:with-initargs (precision scale) jso
               (push underlying initargs)

--- a/src/logical/duration.lisp
+++ b/src/logical/duration.lisp
@@ -288,9 +288,14 @@
                     "logicalType" "duration"))
               fullname->schema
               enclosing-namespace)
-      (let ((underlying (internal:read-jso (st-json:getjso "type" jso)
-                                           fullname->schema
-                                           enclosing-namespace)))
+      (let ((underlying
+              (internal:read-jso
+               (prog1 jso
+                 (setf (st-json::jso-alist jso)
+                       (delete "logicalType" (st-json::jso-alist jso)
+                               :key #'car :test #'string=)))
+               fullname->schema
+               enclosing-namespace)))
         (handler-case
             (make-instance 'api:duration :underlying underlying)
           (error ()

--- a/src/schema.lisp
+++ b/src/schema.lisp
@@ -236,10 +236,17 @@
     ((schema api:logical-schema) seen canonical-form-p)
   (let ((underlying (internal:write-jso
                      (internal:underlying schema) seen canonical-form-p)))
-    (apply #'st-json:jso
-           (list* "type" underlying
-                  "logicalType" (internal:logical-name schema)
-                  (call-next-method)))))
+    (unless (st-json::jso-p underlying)
+      (setf underlying (st-json:jso "type" underlying)))
+    (setf (st-json::jso-alist underlying)
+          (nconc (st-json::jso-alist underlying)
+                 (list (cons "logicalType" (internal:logical-name schema)))))
+    (loop
+      #:for (key value) #:on (call-next-method) #:by #'cddr
+      #:do (setf (st-json::jso-alist underlying)
+                 (nconc (st-json::jso-alist underlying)
+                        (list (cons key value))))
+      #:finally (return underlying))))
 
 (defmethod internal:write-jso
     ((schema api:logical-schema) seen canonical-form-p)

--- a/test/logical/decimal.lisp
+++ b/test/logical/decimal.lisp
@@ -180,26 +180,22 @@
 
 (define-schema-test schema-fixed
   {
-    "type": {
-      "type": "fixed",
-      "name": "foo",
-      "size": 2
-    },
-    "logicalType": "decimal",
-    "precision": 4,
-    "scale": 2
+  "type": "fixed",
+  "name": "foo",
+  "size": 2,
+  "logicalType": "decimal",
+  "precision": 4,
+  "scale": 2
   }
   {
-    "type": {
-      "name": "foo",
-      "type": "fixed",
-      "size": 2
-    },
-    "logicalType": "decimal",
-    "precision": 4,
-    "scale": 2
+  "name": "foo",
+  "type": "fixed",
+  "size": 2,
+  "logicalType": "decimal",
+  "precision": 4,
+  "scale": 2
   }
-  #x38262a1302a1557f
+  #x2d0126a63b744038
   (make-instance
    'avro:decimal
    :underlying (make-instance
@@ -236,26 +232,22 @@
 
 (define-schema-test schema-fixed-same-scale-and-precision
   {
-    "type": {
-      "type": "fixed",
-      "name": "foo",
-      "size": 4
-    },
+    "type": "fixed",
+    "name": "foo",
+    "size": 4,
     "logicalType": "decimal",
     "precision": 4,
     "scale": 4
   }
   {
-    "type": {
-      "name": "foo",
-      "type": "fixed",
-      "size": 4
-    },
+    "name": "foo",
+    "type": "fixed",
+    "size": 4,
     "logicalType": "decimal",
     "precision": 4,
     "scale": 4
   }
-  #x6cc413011b16903f
+  #x4f28f84ecb23847f
   (make-instance
    'avro:decimal
    :underlying (make-instance
@@ -292,24 +284,20 @@
 
 (define-schema-test schema-fixed-default-scale
   {
-    "type": {
-      "type": "fixed",
-      "name": "foo",
-      "size": 4
-    },
+    "type": "fixed",
+    "name": "foo",
+    "size": 4,
     "logicalType": "decimal",
     "precision": 4,
   }
   {
-    "type": {
-      "name": "foo",
-      "type": "fixed",
-      "size": 4
-    },
+    "name": "foo",
+    "type": "fixed",
+    "size": 4,
     "logicalType": "decimal",
     "precision": 4
   }
-  #xa67f01d3bbb18067
+  #xd4d0cf1bd485575d
   (make-instance
    'avro:decimal
    :underlying (make-instance

--- a/test/logical/duration.lisp
+++ b/test/logical/duration.lisp
@@ -32,22 +32,18 @@
 
 (define-schema-test schema
   {
-    "type": {
-      "type": "fixed",
-      "name": "foo",
-      "size": 12
-    },
+    "type": "fixed",
+    "name": "foo",
+    "size": 12,
     "logicalType": "duration"
   }
   {
-    "type": {
-      "name": "foo",
-      "type": "fixed",
-      "size": 12
-    },
+    "name": "foo",
+    "type": "fixed",
+    "size": 12,
     "logicalType": "duration"
   }
-  #x49f6bf2b9652c399
+  #x32c5d8454be57da6
   (make-instance
    'avro:duration
    :underlying (make-instance


### PR DESCRIPTION
Logical schemas should not have a nested type field.